### PR TITLE
Fix snap view selection, add getter

### DIFF
--- a/horizontal-picker/src/main/java/com/github/jhonnyx2012/horizontalpicker/HorizontalPicker.java
+++ b/horizontal-picker/src/main/java/com/github/jhonnyx2012/horizontalpicker/HorizontalPicker.java
@@ -143,6 +143,10 @@ public class HorizontalPicker extends LinearLayout implements HorizontalPickerLi
     return dateChangedSubject;
   }
 
+  public @Nullable LocalDate getSelectedDate() {
+    return rvDays.getSelectedDate();
+  }
+
   public HorizontalPicker setDays(int days) {
     this.days = days;
     return this;

--- a/horizontal-picker/src/main/java/com/github/jhonnyx2012/horizontalpicker/HorizontalPickerRecyclerView.java
+++ b/horizontal-picker/src/main/java/com/github/jhonnyx2012/horizontalpicker/HorizontalPickerRecyclerView.java
@@ -169,6 +169,14 @@ public class HorizontalPickerRecyclerView extends RecyclerView implements OnItem
     ((LinearLayoutManager) getLayoutManager()).scrollToPositionWithOffset(offset, 0);
   }
 
+  public @Nullable LocalDate getSelectedDate() {
+    if (adapter.getSelectedPosition() != -1) {
+      return adapter.getItem(adapter.getSelectedPosition()).getDate();
+    } else {
+      return null;
+    }
+  }
+
   private static class CenterSmoothScroller extends LinearSmoothScroller {
 
     CenterSmoothScroller(Context context) {

--- a/horizontal-picker/src/main/java/com/github/jhonnyx2012/horizontalpicker/HorizontalPickerRecyclerView.java
+++ b/horizontal-picker/src/main/java/com/github/jhonnyx2012/horizontalpicker/HorizontalPickerRecyclerView.java
@@ -7,7 +7,6 @@ import android.support.v7.widget.LinearSmoothScroller;
 import android.support.v7.widget.LinearSnapHelper;
 import android.support.v7.widget.RecyclerView;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.View;
 import android.view.ViewTreeObserver;
 
@@ -104,7 +103,6 @@ public class HorizontalPickerRecyclerView extends RecyclerView implements OnItem
           int position = viewHolder.getAdapterPosition();
           if (position != -1 && position != adapter.getSelectedPosition()) {
             adapter.getSelectedPosition();
-            Log.d("selection", "Scroll Idle select " + position);
             selectItem(position, true);
           }
           break;
@@ -141,7 +139,6 @@ public class HorizontalPickerRecyclerView extends RecyclerView implements OnItem
   public void onClickView(View v, int adapterPosition) {
     if (adapterPosition != adapter.getSelectedPosition()
         && adapter.getItemViewType(adapterPosition) != R.layout.item_placeholder) {
-      Log.d("selection", "onClickView " + adapterPosition);
       selectItem(adapterPosition, true);
       if (scrollToSelectedPosition) {
         smoothScrollToPosition(adapterPosition);
@@ -162,7 +159,6 @@ public class HorizontalPickerRecyclerView extends RecyclerView implements OnItem
   }
 
   public void setDate(LocalDate date) {
-    Log.d("selection", "set date " + date);
     Day firstDay = adapter.getItem(DUMMY_VIEW_OFFSET);
     final int offset = (int) ChronoUnit.DAYS.between(firstDay.getDate(), date);
     selectItem(offset + DUMMY_VIEW_OFFSET, false);


### PR DESCRIPTION
- Fixed issue where an incorrect day would be selected when the recyclerView snaps after scroll or fling.
- Added a getter to retrieve the current selected date.